### PR TITLE
Fix TF for simulation and bringup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ ROS Ragnar depends on the following core packages:
 
 **Please note that you will need the most recent versions of the debians for 'robot_state_publisher' as of 24 Nov, 2015. Please 'apt-get update' if you have not**
 
+**Please note that you will need an RViz version > 1.11.8**
+
 ## Simulation
 If you want to simulate the robot:
 ```

--- a/ragnar_drivers/CMakeLists.txt
+++ b/ragnar_drivers/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED
     rospy
     sensor_msgs
     industrial_utils
+    industrial_robot_client
     ragnar_kinematics
     actionlib
 )

--- a/ragnar_state_publisher/src/ragnar_state_publisher.cpp
+++ b/ragnar_state_publisher/src/ragnar_state_publisher.cpp
@@ -146,88 +146,93 @@ void rsp::RagnarStatePublisher::updateJointPosition(const sensor_msgs::JointStat
 
   // using intermediate points, calculate transform to each link in model
 
-  tf::Transform upper_link, lower_link, ee_link, base_link;
+  tf::Transform upper_link, lower_link, ee_link;
+  std::vector <tf::StampedTransform> tf_update;
   // Joint 1
   calculateDirectedTransform(pts.A.col(0), pts.B.col(0),zi_[0],upper_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(upper_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "upper_arm_4"));
+  tf_update.push_back(tf::StampedTransform(upper_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "upper_arm_4"));
+
   calculateDirectedTransform(pts.B1.col(0), pts.C1.col(0),zi_[0],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_4a"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_4a"));
+
   calculateDirectedTransform(pts.B2.col(0), pts.C2.col(0),zi_[0],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_4b"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_4b"));
   // Joint 2
   calculateDirectedTransform(pts.A.col(1), pts.B.col(1),zi_[1],upper_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(upper_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "upper_arm_3"));
+  tf_update.push_back(tf::StampedTransform(upper_link,joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "upper_arm_3"));
+
   calculateDirectedTransform(pts.B1.col(1), pts.C1.col(1),zi_[1],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_3a"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_3a"));
+
   calculateDirectedTransform(pts.B2.col(1), pts.C2.col(1),zi_[1],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_3b"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_3b"));
   // Joint 3
   calculateDirectedTransform(pts.A.col(2), pts.B.col(2),zi_[2],upper_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(upper_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "upper_arm_2"));
+  tf_update.push_back(tf::StampedTransform(upper_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "upper_arm_2"));
   calculateDirectedTransform(pts.B1.col(2), pts.C1.col(2),zi_[2],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_2a"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_2a"));
   calculateDirectedTransform(pts.B2.col(2), pts.C2.col(2),zi_[2],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_2b"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_2b"));
   // Joint 4
   calculateDirectedTransform(pts.A.col(3), pts.B.col(3),zi_[3],upper_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(upper_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "upper_arm_1"));
+  tf_update.push_back(tf::StampedTransform(upper_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "upper_arm_1"));
   calculateDirectedTransform(pts.B1.col(3), pts.C1.col(3),zi_[3],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_1a"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_1a"));
   calculateDirectedTransform(pts.B2.col(3), pts.C2.col(3),zi_[3],lower_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(lower_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "lower_arm_1b"));
+  tf_update.push_back(tf::StampedTransform(lower_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "lower_arm_1b"));
   // EE link
   ee_link.setIdentity();
   calculateEELinkTransform(pts.C,ee_link);
-  tf_broadcaster_.sendTransform(tf::StampedTransform(ee_link,
-                                                     joints->header.stamp,
-                                                     prefix_ + "base_link",
-                                                     prefix_ + "ee_link"));
+  tf_update.push_back(tf::StampedTransform(ee_link,
+                                           joints->header.stamp,
+                                           prefix_ + "base_link",
+                                           prefix_ + "ee_link"));
   // Base to World
   tf::Transform identity;
   identity.setIdentity();
-  tf_broadcaster_.sendTransform(tf::StampedTransform(identity,
-                                                       joints->header.stamp,
-                                                       prefix_ + "world",
-                                                       prefix_ + "base_link"));
+  tf_update.push_back(tf::StampedTransform(identity,
+                                           joints->header.stamp,
+                                           prefix_ + "world",
+                                           prefix_ + "base_link"));
   // tool0 to EE link
-  tf_broadcaster_.sendTransform(tf::StampedTransform(identity,
-                                                       joints->header.stamp,
-                                                       prefix_ + "ee_link",
-                                                       prefix_ + "tool0"));
+  tf_update.push_back(tf::StampedTransform(identity,
+                                           joints->header.stamp,
+                                           prefix_ + "ee_link",
+                                           prefix_ + "tool0"));
+  tf_broadcaster_.sendTransform(tf_update);
 }

--- a/ragnar_state_publisher/src/ragnar_state_publisher.cpp
+++ b/ragnar_state_publisher/src/ragnar_state_publisher.cpp
@@ -218,4 +218,16 @@ void rsp::RagnarStatePublisher::updateJointPosition(const sensor_msgs::JointStat
                                                      joints->header.stamp,
                                                      prefix_ + "base_link",
                                                      prefix_ + "ee_link"));
+  // Base to World
+  tf::Transform identity;
+  identity.setIdentity();
+  tf_broadcaster_.sendTransform(tf::StampedTransform(identity,
+                                                       joints->header.stamp,
+                                                       prefix_ + "world",
+                                                       prefix_ + "base_link"));
+  // tool0 to EE link
+  tf_broadcaster_.sendTransform(tf::StampedTransform(identity,
+                                                       joints->header.stamp,
+                                                       prefix_ + "ee_link",
+                                                       prefix_ + "tool0"));
 }

--- a/ragnar_support/launch/bringup.launch
+++ b/ragnar_support/launch/bringup.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <launch>
-  <arg name="robot_ip" default="192.168.1.240"/>
+  <arg name="robot_ip" default="10.17.88.39"/>
   <arg name="state_port" default="11002"/>
 
   <!-- Load the workcell description to 'robot_description' -->
@@ -17,14 +17,14 @@
     <arg name="robot_ip" value="$(arg robot_ip)"/>
   </include>
 
-  <!-- 
+  <!--
        If you have had other robots or joints in your scene, you would want
        to bring up a 'joint_state_publisher' as well. There is currently an
        issue with the ragnar state publisher that prevents this, however.
   -->
 
   <!-- Robot State Publisher -->
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+<!--  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />-->
 
   <!-- Visualization -->
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find ragnar_support)/urdf.rviz" />

--- a/ragnar_support/launch/simulate.launch
+++ b/ragnar_support/launch/simulate.launch
@@ -15,10 +15,10 @@
     type="ragnar_state_publisher_node" />
 
   <!-- Robot State Publisher -->
-  <node
+  <!-- node
     name="robot_state_publisher"
     pkg="robot_state_publisher"
-    type="robot_state_publisher" />
+    type="robot_state_publisher" /--> 
   
   <!-- Simulation Node -->
   <node


### PR DESCRIPTION
There was a problem with the way transformations were being published to TF, currently there is no need to use a robot state publisher, since the forward kinematics cannot be computed using floating joints nor is it possible for closed kinematic chains. The Ragnar state publisher was publishing each link on its own, this has been addressed by publishing them as a vector all at once at the end of each loop this keeps the update rate of the TF topic within the expected bounds.
